### PR TITLE
Add PDF sharing for scratch card

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,8 @@
       href="https://fonts.googleapis.com/css2?family=Great+Vibes&display=swap"
       rel="stylesheet"
     />
+    <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
   </head>
   <body>
     <header class="header">
@@ -59,8 +61,9 @@
 </div>
           </div>
         </div>
-      </section>
-    </main>
-    <script src="script.js"></script>
+        </section>
+        <button id="share-vale" class="share-btn material-symbols-outlined" aria-label="Compartir vale" style="display:none;">share</button>
+      </main>
+      <script src="script.js"></script>
   </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -33,6 +33,7 @@ window.addEventListener("load", () => {
   const canvas = document.getElementById("scratchCanvas");
   const ctx = canvas.getContext("2d");
   const container = canvas.parentElement;
+  const shareBtn = document.getElementById("share-vale");
 
   let yaRascado = false;
   let drawCount = 0;
@@ -120,6 +121,7 @@ window.addEventListener("load", () => {
       canvas.classList.add("fade-out");
       canvas.style.pointerEvents = "none";
       mostrarSliderDescubre();
+      mostrarBotonCompartir();
     }
   }
 
@@ -140,6 +142,12 @@ window.addEventListener("load", () => {
       swipeContainer.style.display = "block";
       inicializarSliderSwipe();
       sliderInicializado = true;
+    }
+  }
+
+  function mostrarBotonCompartir() {
+    if (shareBtn) {
+      shareBtn.style.display = "block";
     }
   }
 
@@ -212,5 +220,34 @@ window.addEventListener("load", () => {
       document.body.style.userSelect = "";
       dragging = false;
     };
+  }
+
+  if (shareBtn) {
+    shareBtn.addEventListener("click", async () => {
+      try {
+        const scratchCard = document.querySelector(".scratch-card");
+        const canvasImg = await html2canvas(scratchCard);
+        const imgData = canvasImg.toDataURL("image/png");
+        const { jsPDF } = window.jspdf;
+        const pdf = new jsPDF();
+        const width = pdf.internal.pageSize.getWidth();
+        const height = (canvasImg.height * width) / canvasImg.width;
+        pdf.addImage(imgData, "PNG", 0, 0, width, height);
+        const blob = pdf.output("blob");
+        const file = new File([blob], "vale.pdf", { type: "application/pdf" });
+        if (navigator.canShare && navigator.canShare({ files: [file] })) {
+          await navigator.share({ files: [file], title: "Vale" });
+        } else {
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement("a");
+          a.href = url;
+          a.download = "vale.pdf";
+          a.click();
+          URL.revokeObjectURL(url);
+        }
+      } catch (err) {
+        console.error("Error al compartir", err);
+      }
+    });
   }
 });

--- a/style.css
+++ b/style.css
@@ -375,3 +375,19 @@ a,
   60% { transform: translateX(3px);}
   80% { transform: translateX(0);}
 }
+
+.share-btn {
+  display: block;
+  margin: 1rem auto 2rem;
+  background: none;
+  border: none;
+  color: var(--accent);
+  font-size: 2.2rem;
+  cursor: pointer;
+  transition: color 0.3s;
+}
+
+.share-btn:hover,
+.share-btn:active {
+  color: var(--accent-light);
+}


### PR DESCRIPTION
## Summary
- add html2canvas and jsPDF and share button in index page
- style share button
- implement functionality to capture the scratch card as PDF and share or download

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68493f695a84832da831e1a42a0d1fd1