### PR TITLE
Actualiza animación y fondo del menú de catálogo

### DIFF
--- a/catalogo.css
+++ b/catalogo.css
@@ -64,7 +64,7 @@ h1 {
   max-width: 300px;
   margin: 0.5rem 0;
   padding: 1rem 1.5rem;
-  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-light) 100%);
+  background: #1a1a1a;
   border: none;
   border-radius: 50px;
   color: #fff;
@@ -82,15 +82,16 @@ h1 {
   inset: 0;
   padding: 2px;
   border-radius: inherit;
-  background: conic-gradient(var(--accent) 0deg, var(--accent) 5deg, transparent 5deg 360deg);
+  background: conic-gradient(#FFD700 0deg, #FFD700 45deg, transparent 45deg 360deg);
   -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
   -webkit-mask-composite: xor;
           mask-composite: exclude;
   pointer-events: none;
-  animation: girarBorde 3s linear infinite;
+  animation: bordeDorado 4s linear infinite;
+  filter: drop-shadow(0 0 4px #FFD700);
 }
 
-@keyframes girarBorde {
+@keyframes bordeDorado {
   to {
     transform: rotate(1turn);
   }


### PR DESCRIPTION
## Summary
- cambia el color de fondo de los botones del menú a gris oscuro
- elimina la animación previa del puntito y crea un borde dorado animado

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68497d47eb10832d9a0a59fa5e5c6005