### PR TITLE
Add confetti animation to scratch card

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
     />
     <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.5.1/dist/confetti.browser.min.js"></script>
   </head>
   <body>
     <header class="header">

--- a/script.js
+++ b/script.js
@@ -37,6 +37,7 @@ window.addEventListener("load", () => {
 
   let yaRascado = false;
   let drawCount = 0;
+  let confettiLanzado = false;
 
   function dibujarCanvas() {
     if (yaRascado) return;
@@ -122,6 +123,7 @@ window.addEventListener("load", () => {
       canvas.style.pointerEvents = "none";
       mostrarSliderDescubre();
       mostrarBotonCompartir();
+      lanzarConfeti();
     }
   }
 
@@ -149,6 +151,12 @@ window.addEventListener("load", () => {
     if (shareBtn) {
       shareBtn.style.display = "block";
     }
+  }
+
+  function lanzarConfeti() {
+    if (confettiLanzado || typeof confetti !== "function") return;
+    confettiLanzado = true;
+    confetti({ particleCount: 120, spread: 80, origin: { y: 0.6 } });
   }
 
   function inicializarSliderSwipe() {


### PR DESCRIPTION
## Summary
- load `canvas-confetti` library
- trigger confetti animation once the scratch card is fully revealed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849939b9d4c832d88e2ef64fb488917