### PR TITLE
Add tattoo preview screen and selector

### DIFF
--- a/catalogo.css
+++ b/catalogo.css
@@ -299,6 +299,8 @@ h1 {
   max-height: 85%;
   border-radius: 12px;
   box-shadow: 0 0 30px rgba(255, 255, 255, 0.2);
+  background-color: #fff;
+  padding: 1rem;
 }
 
 .cerrar {
@@ -364,6 +366,7 @@ h1 {
   width: 40%;
   transform: translate(-50%, -50%);
   opacity: 0.9;
+  background: none;
   cursor: grab;
   resize: both !important;
   overflow: hidden;
@@ -426,4 +429,31 @@ h1 {
   text-align: center;
   text-decoration: none;
   font-size: 1.2rem;
+}
+
+.pantalla-preview {
+  display: none;
+  position: fixed;
+  z-index: 100;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.9);
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  overflow-y: auto;
+  padding-bottom: 4rem;
+}
+
+#body-part-selector {
+  margin-top: 1rem;
+  color: #eee;
+  text-align: center;
+}
+
+#body-part-selector select {
+  margin-left: 0.5rem;
+  padding: 0.3rem 0.6rem;
 }

--- a/catalogo.html
+++ b/catalogo.html
@@ -89,21 +89,34 @@
         <button id="ver-preview">Ver sobre la piel</button>
       </div>
 
-      <!-- Vista previa del brazo -->
-      <div id="preview-container" style="display: none">
-        <img id="brazo-img" src="assets/brazo.png" alt="Brazo" />
+      
+
+    </div>
+
+    <div id="pantalla-preview" class="pantalla-preview" style="display:none">
+      <span id="cerrar-preview" class="cerrar">&times;</span>
+      <div id="preview-container">
+        <img id="body-img" src="assets/brazo.png" alt="Brazo" />
         <img id="tattoo-preview" src="" alt="Vista previa" />
       </div>
-
+      <div id="body-part-selector">
+        <label>Parte del cuerpo:
+          <select id="body-part-select">
+            <option value="brazo">Brazo</option>
+            <option value="pierna">Pierna</option>
+            <option value="hombro">Hombro</option>
+            <option value="espalda">Espalda</option>
+          </select>
+        </label>
+      </div>
       <div id="controles-tatuaje">
-  <label>Tamaño:
-    <input type="range" id="slider-tamano" min="10" max="150" value="40" />
-  </label>
-  <label>Rotación:
-    <input type="range" id="slider-rotacion" min="-180" max="180" value="0" />
-  </label>
-</div>
-
+        <label>Tamaño:
+          <input type="range" id="slider-tamano" min="10" max="150" value="40" />
+        </label>
+        <label>Rotación:
+          <input type="range" id="slider-rotacion" min="-180" max="180" value="0" />
+        </label>
+      </div>
     </div>
 
     <script src="catalogo.js"></script>

--- a/catalogo.js
+++ b/catalogo.js
@@ -253,13 +253,33 @@ const cerrarModal = document.getElementById("cerrar-modal");
 
 const verPreviewBtn = document.getElementById("ver-preview");
 const tattooPreview = document.getElementById("tattoo-preview");
-const previewContainer = document.getElementById("preview-container");
+const pantallaPreview = document.getElementById("pantalla-preview");
+const cerrarPreview = document.getElementById("cerrar-preview");
+const bodyImg = document.getElementById("body-img");
+const bodyPartSelect = document.getElementById("body-part-select");
+const botonContainer = document.getElementById("boton-container");
+
+const bodyImages = {
+  brazo: "assets/brazo.png",
+  pierna: "assets/pierna.png",
+  hombro: "assets/hombro.png",
+  espalda: "assets/espalda.png",
+};
+
+function actualizarBodyImage() {
+  const parte = bodyPartSelect.value;
+  bodyImg.src = bodyImages[parte] || bodyImages.brazo;
+}
+
+bodyPartSelect.addEventListener("change", actualizarBodyImage);
 
 document.querySelectorAll(".card img").forEach((img) => {
   img.addEventListener("click", () => {
     modal.style.display = "flex";
     modalImg.src = img.src;
-    previewContainer.style.display = "none";
+    pantallaPreview.style.display = "none";
+    modalImg.style.display = "block";
+    botonContainer.style.display = "block";
     tattooPreview.src = "";
     modalImg.focus();
   });
@@ -269,27 +289,49 @@ document.querySelectorAll(".card img").forEach((img) => {
 if (modal) {
   document.addEventListener("keydown", (e) => {
     if (e.key === "Escape" && modal.style.display === "flex") {
-      modal.style.display = "none";
+      if (pantallaPreview.style.display === "flex") {
+        pantallaPreview.style.display = "none";
+        modalImg.style.display = "block";
+        botonContainer.style.display = "block";
+      } else {
+        modal.style.display = "none";
+      }
     }
   });
 }
 
 cerrarModal.addEventListener("click", () => {
   modal.style.display = "none";
+  pantallaPreview.style.display = "none";
 });
 
 modal.addEventListener("click", (e) => {
   if (e.target === modal) {
-    modal.style.display = "none";
+    if (pantallaPreview.style.display === "flex") {
+      pantallaPreview.style.display = "none";
+      modalImg.style.display = "block";
+      botonContainer.style.display = "block";
+    } else {
+      modal.style.display = "none";
+    }
   }
 });
 
 verPreviewBtn.addEventListener("click", () => {
   if (modalImg.src) {
     tattooPreview.src = modalImg.src;
-    previewContainer.style.display = "block";
+    pantallaPreview.style.display = "flex";
+    modalImg.style.display = "none";
+    botonContainer.style.display = "none";
     tattooPreview.style.pointerEvents = "auto";
+    actualizarBodyImage();
   }
+});
+
+cerrarPreview.addEventListener("click", () => {
+  pantallaPreview.style.display = "none";
+  modalImg.style.display = "block";
+  botonContainer.style.display = "block";
 });
 
 // == CONTADOR DE FAVORITOS ==


### PR DESCRIPTION
## Summary
- keep enlarged tattoo images with white background
- add full-screen preview with movable tattoo overlay
- allow selecting body part to test tattoo placement

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684a9d69aab4832d948159822b8d5fdd