### PR TITLE
Fix preview image overflow on iOS

### DIFF
--- a/catalogo.css
+++ b/catalogo.css
@@ -354,7 +354,7 @@ h1 {
   background-color: #fff;
 }
 
-#brazo-img {
+#body-img {
   width: 100%;
   border-radius: 12px;
 }


### PR DESCRIPTION
## Summary
- ensure the tattoo preview arm image scales correctly

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684aa496f180832da7456b4fd7146e92