### PR TITLE
Adjust tattoo preview scaling

### DIFF
--- a/catalogo.html
+++ b/catalogo.html
@@ -277,7 +277,7 @@
       </div>
       <div id="controles-tatuaje">
         <label>Tamaño:
-          <input type="range" id="slider-tamano" min="10" max="150" value="40" />
+          <input type="range" id="slider-tamano" min="0.5" max="3" step="0.1" value="1" />
         </label>
         <label>Rotación:
           <input type="range" id="slider-rotacion" min="-180" max="180" value="0" />

--- a/catalogo.js
+++ b/catalogo.js
@@ -446,7 +446,7 @@ function habilitarGestos(el) {
       const anguloActual = getAngulo(p1, p2);
       const factorEscala = distanciaActual / distanciaInicial;
       let nuevaEscala = escalaInicio * factorEscala;
-      nuevaEscala = Math.max(10, Math.min(150, nuevaEscala));
+      nuevaEscala = Math.max(0.5, Math.min(3, nuevaEscala));
       let nuevaRotacion = rotacionInicio + (anguloActual - anguloInicial) * (180 / Math.PI);
       if (nuevaRotacion > 180) nuevaRotacion -= 360;
       if (nuevaRotacion < -180) nuevaRotacion += 360;
@@ -471,15 +471,14 @@ const sliderRotacion = document.getElementById("slider-rotacion");
 sliderTamano.addEventListener("input", actualizarTransformaciones);
 sliderRotacion.addEventListener("input", actualizarTransformaciones);
 
-let escalaActual = 40; // en porcentaje
+let escalaActual = 1; // factor de escala
 let rotacionActual = 0;
 
 function actualizarTransformaciones() {
-  escalaActual = sliderTamano.value;
-  rotacionActual = sliderRotacion.value;
+  escalaActual = parseFloat(sliderTamano.value);
+  rotacionActual = parseFloat(sliderRotacion.value);
 
-  tattooPreview.style.width = `${escalaActual}%`;
-  tattooPreview.style.transform = `rotate(${rotacionActual}deg) scale(${escalaActual / 40})`;
+  tattooPreview.style.transform = `rotate(${rotacionActual}deg) scale(${escalaActual})`;
 }
 
 habilitarGestos(document.getElementById("tattoo-preview"));


### PR DESCRIPTION
## Summary
- remove `width` manipulation in `actualizarTransformaciones`
- store scale factor directly and clamp between 0.5 and 3
- update slider range to work with scale factor

## Testing
- `node --check catalogo.js`
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_684ae59fc0e8832dbfe271f081c9e496