### PR TITLE
Fix viewport bounce on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -33,7 +33,8 @@ body {
 }
 
 .header {
-  height: 100dvh;
+  height: 100vh;
+  height: 100svh;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -45,7 +46,8 @@ body {
 }
 
 .header--container {
-  min-height: 100dvh;
+  min-height: 100vh;
+  min-height: 100svh;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -92,7 +94,8 @@ body {
 }
 
 .vale--container {
-  min-height: 100dvh;
+  min-height: 100vh;
+  min-height: 100svh;
   color: var(--text-secondary);
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- set key sections to `100svh` to keep layout stable when browser chrome hides/shows

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859593b5d34832daf139b41667efdf8