### PR TITLE
Replace share feature with PDF generation

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@ Aun así, me he permitido reunir algunas ideas que quizá nos inspiren cuando ll
           </div>
         </div>
         </section>
-        <button id="share-vale" class="share-btn material-symbols-outlined" aria-label="Compartir vale" style="display:none;">share</button>
+        <button id="pdf-vale" class="pdf-btn material-symbols-outlined" aria-label="Crear PDF" style="display:none;">picture_as_pdf</button>
       </main>
       <script src="script.js"></script>
   </body>

--- a/script.js
+++ b/script.js
@@ -33,7 +33,7 @@ window.addEventListener("load", () => {
   const canvas = document.getElementById("scratchCanvas");
   const ctx = canvas.getContext("2d");
   const container = canvas.parentElement;
-  const shareBtn = document.getElementById("share-vale");
+  const pdfBtn = document.getElementById("pdf-vale");
 
   let yaRascado = false;
   let drawCount = 0;
@@ -122,7 +122,7 @@ window.addEventListener("load", () => {
       canvas.classList.add("fade-out");
       canvas.style.pointerEvents = "none";
       mostrarSliderDescubre();
-      mostrarBotonCompartir();
+      mostrarBotonPdf();
       lanzarConfeti();
     }
   }
@@ -147,9 +147,9 @@ window.addEventListener("load", () => {
     }
   }
 
-  function mostrarBotonCompartir() {
-    if (shareBtn) {
-      shareBtn.style.display = "block";
+  function mostrarBotonPdf() {
+    if (pdfBtn) {
+      pdfBtn.style.display = "block";
     }
   }
 
@@ -230,8 +230,8 @@ window.addEventListener("load", () => {
     };
   }
 
-  if (shareBtn) {
-    shareBtn.addEventListener("click", async () => {
+  if (pdfBtn) {
+    pdfBtn.addEventListener("click", async () => {
       try {
         const scratchCard = document.querySelector(".scratch-card");
         const canvasImg = await html2canvas(scratchCard, { useCORS: true });
@@ -243,22 +243,14 @@ window.addEventListener("load", () => {
           format: [canvasImg.width, canvasImg.height],
         });
         pdf.addImage(imgData, "PNG", 0, 0, canvasImg.width, canvasImg.height);
-        const blob = pdf.output("blob");
-        const file = new File([blob], "vale.pdf", { type: "application/pdf" });
-        if (navigator.canShare && navigator.canShare({ files: [file] })) {
-          await navigator.share({ files: [file], title: "Vale rascado" });
-        } else if (navigator.share) {
-          const url = URL.createObjectURL(blob);
-          try {
-            await navigator.share({ title: "Vale rascado", url });
-          } finally {
-            URL.revokeObjectURL(url);
-          }
+        if (/iP(ad|hone|od)/.test(navigator.userAgent)) {
+          const url = pdf.output("bloburl");
+          window.open(url, "_blank");
         } else {
           pdf.save("vale.pdf");
         }
       } catch (err) {
-        console.error("Error al compartir", err);
+        console.error("Error al crear el PDF", err);
       }
     });
   }

--- a/style.css
+++ b/style.css
@@ -394,3 +394,19 @@ a,
 .share-btn:active {
   color: var(--accent-light);
 }
+
+.pdf-btn {
+  display: block;
+  margin: 1rem auto 2rem;
+  background: none;
+  border: none;
+  color: var(--accent);
+  font-size: 2.2rem;
+  cursor: pointer;
+  transition: color 0.3s;
+}
+
+.pdf-btn:hover,
+.pdf-btn:active {
+  color: var(--accent-light);
+}


### PR DESCRIPTION
## Summary
- remove the share button and introduce a PDF download button
- style the new button
- generate a PDF for the scratch card, opening it on iOS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68595ac42ba8832d803a8fd176d0328a