### PR TITLE
Improve scratch-card look

### DIFF
--- a/style.css
+++ b/style.css
@@ -154,13 +154,19 @@ body {
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  background: linear-gradient(135deg, #1a1a1a, var(--main-bg));
-  box-shadow: inset 0 0 15px #0006, 0 0 15px #0008;
+  background: linear-gradient(135deg, #111, #2b2b2b);
+  box-shadow: inset 0 0 20px #0008, 0 0 20px #000a;
   padding: 1rem;
   gap: 0.5rem;
-  border: 2px dashed var(--accent);
-  background-image: radial-gradient(#333 1px, transparent 1px);
-  background-size: 10px 10px;
+  border: 4px groove var(--accent-light);
+  background-image:
+    repeating-linear-gradient(
+      45deg,
+      rgba(255, 255, 255, 0.05) 0 2px,
+      transparent 2px 4px
+    ),
+    radial-gradient(#333 1px, transparent 1px);
+  background-size: 10px 10px, 10px 10px;
   background-color: #1a1a1a;
 }
 
@@ -199,10 +205,11 @@ body {
 }
 .scratch-reveal h1 {
   font-family: var(--font-fancy);
-  font-size: 2.4rem;
+  font-size: 3rem;
   letter-spacing: 0.05rem;
   text-transform: none;
   color: var(--accent-light);
+  text-shadow: 2px 2px 3px #000, 0 0 6px var(--accent-light);
 }
 
 


### PR DESCRIPTION
## Summary
- tweak scratch-card borders, texture and shadow
- style title inside the scratch area with bigger font and highlight

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6859756a8af8832d929819b330a10145