### PR TITLE
Fix scratch card size to show swipe button

### DIFF
--- a/style.css
+++ b/style.css
@@ -144,7 +144,7 @@ body {
 .scratch-card {
   position: relative;
   width: 100%;
-  min-height: 400px;
+  min-height: 500px;
   max-width: 300px;
   aspect-ratio: 3/4;
   margin: 0 auto;
@@ -292,7 +292,7 @@ h1::after {
   }
   .scratch-card {
     max-width: 96vw;
-    min-height: 220px;
+    min-height: 320px;
     padding: 0.5rem;
   }
   .vale--container {


### PR DESCRIPTION
## Summary
- enlarge scratch card so the slider fits when revealed

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859778731ac832d8a111744a47981ea