### PR TITLE
Increase scratch card size

### DIFF
--- a/style.css
+++ b/style.css
@@ -144,8 +144,8 @@ body {
 .scratch-card {
   position: relative;
   width: 100%;
-  min-height: 500px;
-  max-width: 300px;
+  min-height: 600px;
+  max-width: 340px;
   aspect-ratio: 3/4;
   margin: 0 auto;
   border-radius: 12px;
@@ -314,7 +314,7 @@ h1::after {
   }
   .scratch-card {
     max-width: 96vw;
-    min-height: 420px;
+    min-height: 80vh;
     padding: 0.5rem;
   }
   .vale--container {


### PR DESCRIPTION
## Summary
- make scratch card taller and a bit wider
- on small screens use `80vh` for height so it fills more of the viewport

## Testing
- `npx prettier --check style.css` *(fails: code style issues)*

------
https://chatgpt.com/codex/tasks/task_e_685bf695c310832d81e363e1f83eae13