### PR TITLE
Improve vintage coupon look

### DIFF
--- a/images/tattoo-machine.svg
+++ b/images/tattoo-machine.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect x="8" y="6" width="20" height="12" fill="none" stroke="black" stroke-width="3"/>
+  <circle cx="18" cy="22" r="6" fill="none" stroke="black" stroke-width="3"/>
+  <circle cx="30" cy="22" r="6" fill="none" stroke="black" stroke-width="3"/>
+  <rect x="18" y="28" width="12" height="14" fill="none" stroke="black" stroke-width="3"/>
+  <line x1="24" y1="42" x2="24" y2="58" stroke="black" stroke-width="3"/>
+  <rect x="20" y="58" width="8" height="6" fill="none" stroke="black" stroke-width="3"/>
+  <line x1="28" y1="6" x2="56" y2="6" stroke="black" stroke-width="3"/>
+  <line x1="56" y1="6" x2="56" y2="24" stroke="black" stroke-width="3"/>
+  <line x1="56" y1="24" x2="40" y2="24" stroke="black" stroke-width="3"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -61,6 +61,7 @@ Aun así, me he permitido reunir algunas ideas que quizá nos inspiren cuando ll
               <span class="material-symbols-outlined">star</span>
             </div>
             <p>Precio: ____________ (ilimitado)</p>
+            <img src="images/tattoo-machine.svg" alt="Máquina de tatuar" class="tattoo-machine" />
             <div id="swipe-container" class="swipe-container" style="display:none;">
   <div class="swipe-track">
     <div class="swipe-thumb" id="swipe-thumb">

--- a/style.css
+++ b/style.css
@@ -170,6 +170,29 @@ body {
   background-color: #1a1a1a;
 }
 
+.scratch-card::before,
+.scratch-card::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: var(--main-bg);
+  border: 4px groove var(--accent-light);
+  pointer-events: none;
+  z-index: 3;
+}
+
+.scratch-card::before {
+  left: -20px;
+}
+
+.scratch-card::after {
+  right: -20px;
+}
+
 #scratchCanvas {
   position: absolute;
   top: 0;
@@ -194,9 +217,10 @@ body {
   flex-direction: column;
   justify-content: space-evenly;
   text-align: center;
+  padding-right: 6rem;
   color: var(--text-secondary);
   font-family: var(--font-main);
-}
+  }
 
 .span1 {
   scale: 2;
@@ -239,6 +263,19 @@ h1::after {
 .scratch-reveal p {
   font-size: 1rem;
   font-family: var(--font-main);
+}
+
+.tattoo-machine {
+  position: absolute;
+  right: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 35%;
+  max-width: 130px;
+  height: auto;
+  filter: invert(100%);
+  opacity: 0.8;
+  pointer-events: none;
 }
 
 .separator {
@@ -320,6 +357,13 @@ h1::after {
   .vale--container {
     border-radius: 1rem;
   }
+  .scratch-reveal {
+    padding-right: 4rem;
+  }
+  .tattoo-machine {
+    width: 50%;
+    max-width: 110px;
+  }
 }
 
 /* Extra: Smooth transitions for interactive elements */
@@ -338,14 +382,17 @@ a,
 
 .swipe-track {
   position: relative;
-  background: linear-gradient(90deg, #2d2d2d 80%, #bfa76f 100%);
+  background: linear-gradient(90deg, #2d2d2d 80%, #bfa76f 100%),
+    linear-gradient(90deg, var(--accent-light), var(--accent));
+  background-origin: padding-box, border-box;
+  background-clip: padding-box, border-box;
   border-radius: 2rem;
   height: 52px;
   display: flex;
   align-items: center;
   overflow: hidden;
   box-shadow: 0 8px 32px #0004;
-  border: 1.5px solid #bfa76f;
+  border: 2px solid transparent;
 }
 
 .swipe-thumb {


### PR DESCRIPTION
## Summary
- decorate scratch card with semicircle cutouts to mimic ticket edges
- add padding for image space and place tattoo machine illustration
- new tattoo machine SVG asset
- style slider track with gradient border and adjust responsive layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685bf7ff18dc832dba191f1d89618026