### PR TITLE
Mejora diseño del vale con fondo e overlay

### DIFF
--- a/style.css
+++ b/style.css
@@ -154,27 +154,28 @@ body {
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  background: linear-gradient(135deg, #111, #2b2b2b);
   box-shadow: inset 0 0 20px #0008, 0 0 20px #000a;
   padding: 1rem;
   gap: 0.5rem;
   border: 4px groove var(--accent-light);
-  background-image:
-    repeating-linear-gradient(
-      45deg,
-      rgba(255, 255, 255, 0.05) 0 2px,
-      transparent 2px 4px
-    ),
-    radial-gradient(#333 1px, transparent 1px);
-  background-size: 10px 10px, 10px 10px;
-  background-color: #1a1a1a;
+  background-image: url("imagenes/tatuador.png");
+  background-size: cover;
+  background-position: center;
+}
+
+.scratch-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.6);
+  z-index: 1;
 }
 
 #scratchCanvas {
   position: absolute;
   top: 0;
   left: 0;
-  z-index: 2;
+  z-index: 3;
   touch-action: none;
   transition: opacity 0.6s ease;
   opacity: 1;
@@ -188,7 +189,7 @@ body {
 }
 
 .scratch-reveal {
-  z-index: 0;
+  z-index: 2;
   height: 100%;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- actualiza el fondo de la tarjeta usando `imagenes/tatuador.png`
- añade capa semitransparente sobre la tarjeta
- ajusta la jerarquía de capas para que el texto siga visible

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685bfe1bd3e4832d9852d904e24c4f13