### PR TITLE
Modify scratch card text layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,13 +54,13 @@ Aun así, me he permitido reunir algunas ideas que quizá nos inspiren cuando ll
               <span class="material-symbols-outlined">star</span>
               <span class="material-symbols-outlined">star</span>
             </div>
-            <p>Fecha: ____________ (lo antes posible)</p>
+            <p>Fecha: ____________<br><span class="nota">(lo antes posible)</span></p>
             <div class="separator" aria-hidden="true">
               <span class="material-symbols-outlined">star</span>
               <span class="material-symbols-outlined">star</span>
               <span class="material-symbols-outlined">star</span>
             </div>
-            <p>Precio: ____________ (ilimitado)</p>
+            <p>Precio: ____________<br><span class="nota">(ilimitado)</span></p>
             <div id="swipe-container" class="swipe-container" style="display:none;">
   <div class="swipe-track">
     <div class="swipe-thumb" id="swipe-thumb">

--- a/style.css
+++ b/style.css
@@ -189,6 +189,7 @@ body {
 }
 
 .scratch-reveal {
+  position: relative;
   z-index: 2;
   height: 100%;
   display: flex;
@@ -197,9 +198,14 @@ body {
   text-align: center;
   color: var(--text-secondary);
   font-family: var(--font-main);
+  padding-top: 3rem;
 }
 
 .span1 {
+  position: absolute;
+  top: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
   scale: 2;
   color: var(--accent);
   filter: drop-shadow(0 0 3px #fff9) drop-shadow(0 0 10px #fff9);
@@ -240,6 +246,11 @@ h1::after {
 .scratch-reveal p {
   font-size: 1rem;
   font-family: var(--font-main);
+}
+
+.nota {
+  font-size: 0.9rem;
+  color: var(--accent-light);
 }
 
 .separator {


### PR DESCRIPTION
## Summary
- put optional text below the underscores for the date and price
- position gift icon at the top of the card
- style the new optional note text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c02b627c8832dad34fc004e25b67c