### PR TITLE
Implement temporary scratch patches

### DIFF
--- a/script.js
+++ b/script.js
@@ -38,6 +38,8 @@ window.addEventListener("load", () => {
   let yaRascado = false;
   let drawCount = 0;
   let confettiLanzado = false;
+  let scratchGrad = null;
+  const LIMITE_RASCADO = 400;
 
   function dibujarCanvas() {
     if (yaRascado) return;
@@ -57,6 +59,7 @@ window.addEventListener("load", () => {
 
     ctx.fillStyle = grad;
     ctx.fillRect(0, 0, width, height);
+    scratchGrad = grad;
 
     // Líneas diagonales sutiles
     ctx.lineWidth = 4;
@@ -112,19 +115,47 @@ window.addEventListener("load", () => {
     ctx.fill();
 
     checkScratchProgress();
+    crearParcheTemporal();
   }
 
   // SOLO UNA función checkScratchProgress
   function checkScratchProgress() {
     drawCount++;
-    const limiteRascado = 400;
-    if (drawCount >= limiteRascado) {
+    if (drawCount >= LIMITE_RASCADO) {
       canvas.classList.add("fade-out");
       canvas.style.pointerEvents = "none";
       mostrarSliderDescubre();
       mostrarBotonPdf();
       lanzarConfeti();
     }
+  }
+
+  function crearParcheTemporal() {
+    if (!scratchGrad) return;
+    if (drawCount < 20 || drawCount > LIMITE_RASCADO - 40) return;
+    if (Math.random() > 0.15) return;
+
+    const radio = Math.max(canvas.width, canvas.height) * 0.05 * (1 + Math.random());
+    const x = Math.random() * canvas.width;
+    const y = Math.random() * canvas.height;
+
+    ctx.save();
+    ctx.globalCompositeOperation = "source-over";
+    ctx.fillStyle = scratchGrad;
+    ctx.beginPath();
+    ctx.arc(x, y, radio, 0, 2 * Math.PI);
+    ctx.fill();
+    ctx.restore();
+
+    const delay = 800 + Math.random() * 1000;
+    setTimeout(() => {
+      ctx.save();
+      ctx.globalCompositeOperation = "destination-out";
+      ctx.beginPath();
+      ctx.arc(x, y, radio, 0, 2 * Math.PI);
+      ctx.fill();
+      ctx.restore();
+    }, delay);
   }
 
   canvas.addEventListener("mousemove", (e) => {


### PR DESCRIPTION
## Summary
- add `crearParcheTemporal` that briefly covers random spots after scratching
- record the scratch gradient and use constant `LIMITE_RASCADO`
- randomly re-cover and reveal areas for a playful effect

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686e37aeace4832d80e2cf134b90c33b