### PR TITLE
Add scratch card progress messages

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@ Aun así, me he permitido reunir algunas ideas que quizá nos inspiren cuando ll
       <section class="vale--container">
         <div class="scratch-card">
           <canvas id="scratchCanvas"></canvas>
+          <div id="scratch-msg" class="scratch-msg" aria-live="polite"></div>
 
           <!-- Contenido revelado tras rascar -->
           <div class="scratch-reveal">

--- a/script.js
+++ b/script.js
@@ -34,6 +34,21 @@ window.addEventListener("load", () => {
   const ctx = canvas.getContext("2d");
   const container = canvas.parentElement;
   const pdfBtn = document.getElementById("pdf-vale");
+  const scratchMsg = document.getElementById("scratch-msg");
+
+  function showScratchMsg(msg) {
+    if (!scratchMsg) return;
+    scratchMsg.textContent = msg;
+    scratchMsg.style.opacity = "1";
+    clearTimeout(scratchMsg._t);
+    scratchMsg._t = setTimeout(() => (scratchMsg.style.opacity = "0"), 1200);
+  }
+
+  function hideScratchMsg() {
+    if (!scratchMsg) return;
+    scratchMsg.textContent = "";
+    scratchMsg.style.opacity = "0";
+  }
 
   let yaRascado = false;
   let drawCount = 0;
@@ -142,12 +157,18 @@ window.addEventListener("load", () => {
   function checkScratchProgress() {
     drawCount++;
     const limiteRascado = 900;
-    if (drawCount >= limiteRascado) {
+    const progreso = drawCount / limiteRascado;
+    if (progreso >= 1) {
+      hideScratchMsg();
       canvas.classList.add("fade-out");
       canvas.style.pointerEvents = "none";
       mostrarSliderDescubre();
       mostrarBotonPdf();
       lanzarConfeti();
+    } else if (progreso >= 0.75) {
+      showScratchMsg("Casi lo tienes…");
+    } else if (progreso >= 0.25) {
+      showScratchMsg("¡Más fuerte!");
     }
   }
 

--- a/style.css
+++ b/style.css
@@ -188,6 +188,22 @@ body {
   transition: opacity 0.6s ease;
 }
 
+.scratch-msg {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 4;
+  font-family: var(--font-main);
+  color: var(--accent-light);
+  background: rgba(0, 0, 0, 0.6);
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
 .scratch-reveal {
   position: relative;
   z-index: 2;


### PR DESCRIPTION
## Summary
- add scratch progress message element to the scratch card
- style the temporary scratch message overlay
- show messages while scratching and hide them when finished

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686e40cc1b2c832daaafa53d9524ce73